### PR TITLE
Cleanup dependencies, add caching, test more node envs, some features

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+test
+.travis.yml
+.npmignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - 'stable'
+  - '5'
   - 'iojs'
   - '0.12'
   - '0.10'

--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@ module.exports = function (content, sourceMap) {
   }
 
   return "module.exports = {" + files.map(function (file) {
-    var absFile = path.resolve(resourceDir, file);
-    this.addDependency(absFile);
-    return JSON.stringify(file) + ": require(" + JSON.stringify(absFile) + ")"
+    this.addDependency(path.resolve(resourceDir, file));
+
+    var stringifiedFile = JSON.stringify(file);
+    return stringifiedFile + ": require(" + stringifiedFile + ")";
   }.bind(this)).join(",\n") + "\n};"
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var glob = require("glob");
 var path = require("path");
 
 module.exports = function (content, sourceMap) {
+  this.cacheable && this.cacheable();
   var resourceDir = path.dirname(this.resourcePath);
   var files = glob.sync(content.trim(), {
     cwd: resourceDir

--- a/index.js
+++ b/index.js
@@ -7,16 +7,16 @@ module.exports = function (content, sourceMap) {
   var resourceDir = path.dirname(this.resourcePath);
   var pattern = content.trim();
   var files = glob.sync(pattern, {
-    cwd: resourceDir,
-    realpath: true
+    cwd: resourceDir
   });
 
   if (!files.length) {
     this.emitWarning('Did not find anything for glob "' + pattern + '" in directory "' + resourceDir + '"');
   }
 
-  return "module.exports = [\n" + files.map(function (file) {
-    this.addDependency(file);
-    return "  require(" + JSON.stringify(file) + ")"
-  }.bind(this)).join(",\n") + "\n];"
+  return "module.exports = {" + files.map(function (file) {
+    var absFile = path.resolve(resourceDir, file);
+    this.addDependency(absFile);
+    return JSON.stringify(file) + ": require(" + JSON.stringify(absFile) + ")"
+  }.bind(this)).join(",\n") + "\n};"
 };

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = function (content, sourceMap) {
   var resourceDir = path.dirname(this.resourcePath);
   var pattern = content.trim();
   var files = glob.sync(pattern, {
-    cwd: resourceDir
+    cwd: resourceDir,
+    realpath: true
   });
 
   if (!files.length) {
@@ -16,6 +17,7 @@ module.exports = function (content, sourceMap) {
   }
 
   return "module.exports = [\n" + files.map(function (file) {
+    this.addDependency(file);
     return "  require(" + JSON.stringify(file) + ")"
-  }).join(",\n") + "\n];"
+  }.bind(this)).join(",\n") + "\n];"
 };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var glob = require("glob");
 var path = require("path");
 
 module.exports = function (content, sourceMap) {
+  this.cacheable && this.cacheable();
   var resourceDir = path.dirname(this.resourcePath);
   var pattern = content.trim();
   var files = glob.sync(pattern, {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 "use strict";
 
-var loaderUtils = require("loader-utils");
 var glob = require("glob");
 var path = require("path");
 
 module.exports = function (content, sourceMap) {
-  // var query = loaderUtils.parseQuery(this.query);
   var resourceDir = path.dirname(this.resourcePath);
   var files = glob.sync(content.trim(), {
     cwd: resourceDir

--- a/index.js
+++ b/index.js
@@ -6,9 +6,14 @@ var path = require("path");
 module.exports = function (content, sourceMap) {
   this.cacheable && this.cacheable();
   var resourceDir = path.dirname(this.resourcePath);
-  var files = glob.sync(content.trim(), {
+  var pattern = content.trim();
+  var files = glob.sync(pattern, {
     cwd: resourceDir
   });
+
+  if (!files.length) {
+    this.emitWarning('Did not find anything for glob "' + pattern + '" in directory "' + resourceDir + '"');
+  }
 
   return "module.exports = [\n" + files.map(function (file) {
     return "  require(" + JSON.stringify(file) + ")"

--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ module.exports = function (content, sourceMap) {
     this.emitWarning('Did not find anything for glob "' + pattern + '" in directory "' + resourceDir + '"');
   }
 
-  return "module.exports = {" + files.map(function (file) {
+  return "module.exports = {\n" + files.map(function (file) {
     this.addDependency(path.resolve(resourceDir, file));
 
     var stringifiedFile = JSON.stringify(file);
-    return stringifiedFile + ": require(" + stringifiedFile + ")";
+    return "\t" + stringifiedFile + ": require(" + stringifiedFile + ")";
   }.bind(this)).join(",\n") + "\n};"
 };

--- a/index.js
+++ b/index.js
@@ -20,5 +20,5 @@ module.exports = function (content, sourceMap) {
 
     var stringifiedFile = JSON.stringify(file);
     return "\t" + stringifiedFile + ": require(" + stringifiedFile + ")";
-  }.bind(this)).join(",\n") + "\n};"
+  }, this).join(",\n") + "\n};"
 };

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var glob = require("glob");
 var path = require("path");
 
 module.exports = function (content, sourceMap) {
-  this.cacheable && this.cacheable();
   var resourceDir = path.dirname(this.resourcePath);
   var pattern = content.trim();
   var files = glob.sync(pattern, {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/seanchas116/glob-loader#readme",
   "dependencies": {
     "glob": "^5.0.10",
-    "loader-utils": "^0.2.9"
   },
   "keywords": [
     "webpack",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "glob"
   ],
   "devDependencies": {
-    "tap": "^1.2.0",
     "glob": "^7.0.5",
+    "tap": "^7.1.2",
     "webpack": "^1.9.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glob-loader",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "webpack loader to load files at once with glob",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "url": "https://github.com/seanchas116/glob-loader/issues"
   },
   "homepage": "https://github.com/seanchas116/glob-loader#readme",
-  "dependencies": {
-    "glob": "^5.0.10",
+  "dependencies": {},
+  "peerDependencies": {
+    "glob": "*"
   },
   "keywords": [
     "webpack",
@@ -27,6 +28,7 @@
   ],
   "devDependencies": {
     "tap": "^1.2.0",
+    "glob": "^7.0.5",
     "webpack": "^1.9.10"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,12 @@
 var test = require("tap").test;
 var testBundle = require("./sample/bundle");
+var a = require("./sample/dir/a.js");
+var b = require("./sample/dir/b.js");
 
 test("glob-loader", function (t) {
-  t.similar(testBundle, ["a", "b"]);
+  t.similar(testBundle, {
+      "./dir/a.js": a,
+      "./dir/b.js": b,
+  });
   t.end()
 });


### PR DESCRIPTION
This PR cleans up the dependencies a little bit:
- `glob` is now a peerDependency, so on a new glob release the loader does not need to be updated. This is a best-practice for loaders.
- Removed the unused `loader-utils` dependency
- Updated `tap` to latest stable

Furthermore:
- Made the loader cacheable
- Added testing on Node 5 and stable to the Travis build
- Warn if no files are matched by the pattern
- Mark matched files as dependent for webpack to watch
- Return an object map with file -> required result - fixes #4 
- makes sure test files are not packaged
- bumps version to `0.3.0`
